### PR TITLE
build: update decky-frontend-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "decky-frontend-lib": "^3.20.5",
+        "decky-frontend-lib": "^3.20.7",
         "fast-levenshtein": "^3.0.0",
         "localforage": "^1.10.0",
         "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   decky-frontend-lib:
-    specifier: ^3.20.5
-    version: 3.20.5
+    specifier: ^3.20.7
+    version: 3.20.7
   fast-levenshtein:
     specifier: ^3.0.0
     version: 3.0.0
@@ -770,8 +770,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /decky-frontend-lib@3.20.5:
-    resolution: {integrity: sha512-aXllFYhWovoiyBHNzH8PW9EYgXotY9ysuU9icFNgrOWFotyJV+2KGLnfYEyBlDNiexKvXKVRKPw1gRFX2hP4AQ==}
+  /decky-frontend-lib@3.20.7:
+    resolution: {integrity: sha512-Zwwbo50cqpTbCfSCZaqITgTRvWs7pK9KO1A+Oo2sCC/DqOfyUtEH5niNPid4Qxu+yh4lsbEjTurJk1nCfd+nZw==}
     dev: false
 
   /deepmerge@4.3.1:


### PR DESCRIPTION
Update decky-frontend-lib to fix [plugin runtime issues on the latest steam beta](https://github.com/SteamDeckHomebrew/decky-loader/issues/448)