### PR TITLE
Add non-english game title support

### DIFF
--- a/src/components/GameStats/GameStats.tsx
+++ b/src/components/GameStats/GameStats.tsx
@@ -1,5 +1,6 @@
 import { DialogButtonPrimary, Navigation, ServerAPI } from 'decky-frontend-lib';
 import useHltb from '../../hooks/useHltb';
+import useSteam from '../../hooks/useSteam';
 import { usePreference, useStyle } from '../../hooks/useStyle';
 import style from './style';
 
@@ -11,8 +12,9 @@ type GameStatsProps = {
 };
 
 export const GameStats = ({ serverApi, game, appId, id }: GameStatsProps) => {
+    const { new_game } = useSteam(appId, game, serverApi);
     const { mainStat, mainPlusStat, completeStat, allStylesStat, gameId } =
-        useHltb(appId, game, serverApi);
+        useHltb(appId, new_game, serverApi);
     const hltbStyle = useStyle();
     const hideDetails = usePreference();
     const baseClass = hltbStyle === null ? 'hltb-info-absolute' : 'hltb-info';

--- a/src/hooks/useHltb.ts
+++ b/src/hooks/useHltb.ts
@@ -49,11 +49,14 @@ const useHltb = (appId: number, game: string, serverApi: ServerAPI) => {
     };
     useEffect(() => {
         const getData = async () => {
+            console.log('run useHltb');
             const cache = await getCache<HLTBStats>(`${appId}`);
             if (cache && !needCacheUpdate(cache.lastUpdatedAt)) {
                 setStats(cache);
+            } else if (game.trim() == '') {
+                return;
             } else {
-                console.log(`get HLTB data for ${appId} and ${game}`);
+                console.log(`get HLTB data for ${appId} and '${game}'`);
                 const res: ServerResponse<HLTBResult> =
                     await serverApi.fetchNoCors<HLTBResult>(
                         'https://howlongtobeat.com/api/search',
@@ -147,7 +150,7 @@ const useHltb = (appId: number, game: string, serverApi: ServerAPI) => {
         if (appId) {
             getData();
         }
-    }, [appId]);
+    }, [appId, game]);
 
     return {
         ...stats,

--- a/src/hooks/useSteam.ts
+++ b/src/hooks/useSteam.ts
@@ -1,0 +1,65 @@
+import { ServerAPI, ServerResponse } from 'decky-frontend-lib';
+import { useState, useEffect } from 'react';
+import { getCache, updateCache } from './Cache';
+import { normalize } from '../utils';
+
+type SteamResult = { body: string; status: number };
+type SteamStats = {
+    new_game: string;
+};
+
+// Hook to get data from Steam
+const useSteam = (appId: number, game: string, serverApi: ServerAPI) => {
+    const [stats, setStats] = useState<SteamStats>({
+        new_game: '',
+    });
+    useEffect(() => {
+        const getData = async () => {
+            console.log('run useSteam');
+            const cache = await getCache<SteamStats>(`name_${appId}`);
+            if (cache) {
+                console.log(
+                    `get steam name from cache => '${cache['new_game']}'`
+                );
+                setStats(cache);
+            } else if (game.trim() != '') {
+                console.log('use original name');
+                let newStats = { new_game: game };
+                setStats(newStats);
+            } else {
+                console.log(`get Steam data for ${appId}`);
+                const res: ServerResponse<SteamResult> =
+                    await serverApi.fetchNoCors<SteamResult>(
+                        `https://store.steampowered.com/api/appdetails?appids=${appId}`
+                    );
+                const result = res.result as SteamResult;
+                console.log(`steam status is ${result.status}`);
+
+                if (result.status === 200) {
+                    let obj = JSON.parse(result.body);
+                    const orig_name: string = obj[appId].data.name;
+                    console.log(`orig name is '${orig_name}'`);
+                    const new_name: string = normalize(orig_name);
+                    console.log(`app name is '${new_name}'`);
+                    let newStats = {
+                        new_game: new_name,
+                    };
+                    setStats(newStats);
+                    updateCache(`name_${appId}`, newStats);
+                    console.log(obj);
+                } else {
+                    console.error(result);
+                }
+            }
+        };
+        if (appId) {
+            getData();
+        }
+    }, [appId]);
+
+    return {
+        ...stats,
+    };
+};
+
+export default useSteam;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ export const normalize = (str: string) => {
         .toLowerCase()
         .normalize('NFD')
         .replace(/[\u0300-\u036f]/g, '')
+        .replace(/\(retire\)/g, '')
         .replace(/[^a-zA-Z0-9\-\/\s]/g, '')
         .trim();
 };


### PR DESCRIPTION
First at all, I don't have any experience in web development/typescript/React. I did my best searching on Stackoverflow and google then modifying the source code based on the original hltb-for-deck, so please feel free to reject or modify my changes.


I found the non-english game title will become a empty string after applying normalize function, and it leads the result always points to "https://howlongtobeat.com/game/95647". So instead I using steam api "http://store.steampowered.com/api/appdetails?appids={APP_ID}" to get json information and parsing the english game title, and then pass it to useHtlb. 

Tested languages: Traditional Chinese, Korean, Japanese, Spanish and Russian. All of them work as expected.
Tested steam item: 'Hogwarts Legacy' 990080 , 'Paradise Killer' 1160220, 'Detention' 555220, 'Black Desert' 1258320

During the testing, found steam id 1258320 didn't get correct hltb record, which was due to the item is no longer available on steam and there's a '(retire)' after the game title. Modify the normalize function in src/utils.ts to remove '(retire)' string.

Hogwarts Legacy
![hltb-for-deck-1](https://github.com/hulkrelax/hltb-for-deck/assets/40769/453e49bd-5715-4595-bc9f-929dbc30ac96)

Paradise Killer
![hltb-for-deck-2](https://github.com/hulkrelax/hltb-for-deck/assets/40769/9ed0f53c-f0df-4b23-9529-e2e0e10092a6)
